### PR TITLE
Fix issue 44 : 查询多列（按string过滤）出错

### DIFF
--- a/src/main/java/cn/edu/thu/tsfiledb/engine/overflow/IntervalTreeOperation.java
+++ b/src/main/java/cn/edu/thu/tsfiledb/engine/overflow/IntervalTreeOperation.java
@@ -843,7 +843,7 @@ public class IntervalTreeOperation implements IIntervalTreeOperator {
             case BOOLEAN:
                 return SingleValueVisitorFactory.getSingleValueVisitor(TSDataType.BOOLEAN).satisfyObject(data.getBoolean(i), valueFilter);
             case TEXT:
-                return SingleValueVisitorFactory.getSingleValueVisitor(TSDataType.TEXT).satisfyObject(data.getBinary(i).getStringValue(), valueFilter);
+                return SingleValueVisitorFactory.getSingleValueVisitor(TSDataType.TEXT).satisfyObject(data.getBinary(i), valueFilter);
             default:
                 LOG.error("Unsupported TSFile data type.");
                 throw new UnSupportedDataTypeException("Unsupported TSFile data type.");

--- a/src/test/java/cn/edu/thu/tsfiledb/service/CrossReadBugFixTest.java
+++ b/src/test/java/cn/edu/thu/tsfiledb/service/CrossReadBugFixTest.java
@@ -157,6 +157,25 @@ public class CrossReadBugFixTest {
     }
 
     private void selectWildTest() throws ClassNotFoundException, SQLException {
+        String[] retArray = new String[]{
+                "1,101,1101,7.0",
+                "2,198,198,8.0",
+                "51,null,51,null",
+                "52,null,52,null",
+                "53,null,53,null",
+                "54,null,54,null",
+                "55,null,55,null",
+                "56,null,56,null",
+                "57,null,57,null",
+                "58,null,58,null",
+                "100,300,199,19.0",
+                "101,99,199,10.0",
+                "102,80,180,18.0",
+                "103,99,199,12.0",
+                "104,90,190,13.0",
+                "105,99,199,14.0",
+                "106,99,null,null"
+        };
 
         Class.forName("cn.edu.thu.tsfiledb.jdbc.TsfileDriver");
         Connection connection = null;
@@ -171,7 +190,8 @@ public class CrossReadBugFixTest {
                 while (resultSet.next()) {
                     String ans = resultSet.getString(TIMESTAMP_STR) + "," + resultSet.getString(d0s0) + ","
                             + resultSet.getString(d0s1) + "," + resultSet.getString(d0s2);
-                    System.out.println(ans);
+                    // System.out.println(ans);
+                    Assert.assertEquals(retArray[cnt], ans);
                     cnt++;
                 }
             }
@@ -216,7 +236,7 @@ public class CrossReadBugFixTest {
                 int cnt = 0;
                 while (resultSet.next()) {
                     String ans = resultSet.getString(TIMESTAMP_STR) + "," + resultSet.getString(d0s0) + "," + resultSet.getString(d0s1) + "," + resultSet.getString(d0s2);
-                    System.out.println(ans);
+                    // System.out.println(ans);
                     Assert.assertEquals(retArray[cnt], ans);
                     cnt++;
                 }

--- a/src/test/java/cn/edu/thu/tsfiledb/service/DaemonTest.java
+++ b/src/test/java/cn/edu/thu/tsfiledb/service/DaemonTest.java
@@ -138,7 +138,7 @@ public class DaemonTest {
 
         //TODO: add your query statement
         Connection connection = DriverManager.getConnection("jdbc:tsfile://127.0.0.1:6667/", "root", "root");
-        System.out.println(connection.getMetaData());
+        //System.out.println(connection.getMetaData());
         selectAllSQLTest();
         dnfErrorSQLTest();
         selectWildCardSQLTest();
@@ -146,6 +146,7 @@ public class DaemonTest {
         selectAndOpeCrossTest();
         aggregationTest();
         selectOneColumnWithFilterTest();
+        textDataTypeTest();
         connection.close();
     }
 
@@ -427,6 +428,41 @@ public class DaemonTest {
                     //System.out.println("=====" + ans);
                     Assert.assertEquals(ans, retArray[cnt++]);
                     //AbstractClient.output(resultSet, true, "select statement");
+                }
+                Assert.assertEquals(cnt, 3);
+            }
+            statement.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    private void textDataTypeTest() throws ClassNotFoundException, SQLException {
+        String[] retArray = new String[]{
+                "101,199,null,tomorrow is another day",
+                "102,180,10.0,tomorrow is another day",
+                "946684800000,100,null,good"
+        };
+
+        Class.forName("cn.edu.thu.tsfiledb.jdbc.TsfileDriver");
+        Connection connection = null;
+        try {
+            connection = DriverManager.getConnection("jdbc:tsfile://127.0.0.1:6667/", "root", "root");
+            Statement statement = connection.createStatement();
+
+            boolean hasTextMaxResultSet = statement.execute("select s1,s2,s3 from root.vehicle.d0 where s3 = 'tomorrow is another day' or s3 = 'good'");
+            if (hasTextMaxResultSet) {
+                ResultSet resultSet = statement.getResultSet();
+                int cnt = 0;
+                while (resultSet.next()) {
+                    String ans = resultSet.getString(TIMESTAMP_STR) + "," + resultSet.getString(d0s1) + "," +
+                            resultSet.getString(d0s2) + "," + resultSet.getString(d0s3);
+                    //System.out.println("=====" + ans);
+                    Assert.assertEquals(ans, retArray[cnt++]);
                 }
                 Assert.assertEquals(cnt, 3);
             }

--- a/src/test/java/cn/edu/thu/tsfiledb/service/SmallPageSizeTest.java
+++ b/src/test/java/cn/edu/thu/tsfiledb/service/SmallPageSizeTest.java
@@ -8,12 +8,15 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
 
 import cn.edu.thu.tsfiledb.conf.TsfileDBConfig;
 import cn.edu.thu.tsfiledb.conf.TsfileDBDescriptor;
 import cn.edu.tsinghua.tsfile.common.conf.TSFileConfig;
 import cn.edu.tsinghua.tsfile.common.conf.TSFileDescriptor;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *


### PR DESCRIPTION
这个的主要原因是valueFilter跟overflow过滤时的问题。
valuefilter的值类型为Binary，overflow data里存的是String类型，这样子equals判断会不相等。

主要修改就是src/main/java/cn/edu/thu/tsfiledb/engine/overflow/IntervalTreeOperation.java的代码，其它的部分是添加的测试。