### PR TITLE
redesign when to generate ChunkGroupFooter

### DIFF
--- a/iotdb/src/main/java/cn/edu/tsinghua/iotdb/engine/filenode/FileNodeProcessor.java
+++ b/iotdb/src/main/java/cn/edu/tsinghua/iotdb/engine/filenode/FileNodeProcessor.java
@@ -1429,7 +1429,7 @@ public class FileNodeProcessor extends Processor implements IStatistic {
 							isRowGroupHasData = true;
 							// the datasize and numOfChunk is fake
 							// the accurate datasize and numOfChunk will get after write all this deltaObject data.
-							fileIOWriter.startFlushChunkGroup(deltaObjectId,0,numOfChunk);
+							fileIOWriter.startFlushChunkGroup(deltaObjectId);//TODO please check me.
 							startPos = fileIOWriter.getPos();
 						}
 						// init the serieswWriteImpl

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/engine/bufferwrite/BufferWriteIOTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/engine/bufferwrite/BufferWriteIOTest.java
@@ -41,7 +41,8 @@ public class BufferWriteIOTest {
 		assertEquals(TsFileIOWriter.magicStringBytes.length, bufferWriteIO.getPos());
 		assertEquals(0, bufferWriteIO.getAppendedRowGroupMetadata().size());
 		// construct one rowgroup
-		ChunkGroupFooter chunkGroupFooter =  bufferWriteIO.startFlushChunkGroup("d1",1000,10);
+		bufferWriteIO.startFlushChunkGroup("d1");
+		ChunkGroupFooter chunkGroupFooter = new ChunkGroupFooter("d1", 1000, 10);
 		bufferWriteIO.endChunkGroup(chunkGroupFooter);
 		assertEquals(1, bufferWriteIO.getChunkGroupMetaDatas().size());
 		assertEquals(1, bufferWriteIO.getAppendedRowGroupMetadata().size());
@@ -49,13 +50,16 @@ public class BufferWriteIOTest {
 		ChunkGroupMetaData rowgroup = metadatas.get(0);
 		assertEquals("d1", rowgroup.getDeviceID());
 		// construct another two rowgroup
-		chunkGroupFooter = bufferWriteIO.startFlushChunkGroup("d1",1000,10);
+		bufferWriteIO.startFlushChunkGroup("d1");
+		chunkGroupFooter = new ChunkGroupFooter("d1", 1000, 10);
 		bufferWriteIO.endChunkGroup(chunkGroupFooter);
 
-		chunkGroupFooter = bufferWriteIO.startFlushChunkGroup("d1",1000,10);
+		bufferWriteIO.startFlushChunkGroup("d1");
+		chunkGroupFooter = new ChunkGroupFooter("d1", 1000, 10);
 		bufferWriteIO.endChunkGroup(chunkGroupFooter);
 
-		chunkGroupFooter = bufferWriteIO.startFlushChunkGroup("d1",1000,10);
+		bufferWriteIO.startFlushChunkGroup("d1");
+		chunkGroupFooter = new ChunkGroupFooter("d1", 1000, 10);
 		bufferWriteIO.endChunkGroup(chunkGroupFooter);
 
 		metadatas = bufferWriteIO.getAppendedRowGroupMetadata();

--- a/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/ChunkGroupWriterImpl.java
+++ b/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/ChunkGroupWriterImpl.java
@@ -86,8 +86,7 @@ public class ChunkGroupWriterImpl implements IChunkGroupWriter {
     /**
      * seal all the chunks which may has un-sealed pages in force.
      */
-    @Override
-    public void sealAllChunks() {
+    private void sealAllChunks() {
         for (IChunkWriter writer : chunkWriters.values()) {
             writer.sealCurrentPage();
         }

--- a/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/ChunkWriterImpl.java
@@ -223,7 +223,7 @@ public class ChunkWriterImpl implements IChunkWriter {
 
     @Override
     public void writeToFileWriter(TsFileIOWriter tsfileWriter) throws IOException {
-        preFlush();
+        sealCurrentPage();
         chunkBuffer.writeAllPagesOfSeriesToTsFile(tsfileWriter, chunkStatistics);
         chunkBuffer.reset();
         // reset series_statistics
@@ -243,7 +243,7 @@ public class ChunkWriterImpl implements IChunkWriter {
     }
 
     @Override
-    public void preFlush() {
+    public void sealCurrentPage() {
         if (valueCountInOnePage > 0) {
             writePage();
         }

--- a/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/IChunkGroupWriter.java
+++ b/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/IChunkGroupWriter.java
@@ -1,5 +1,6 @@
 package cn.edu.tsinghua.tsfile.write.chunk;
 
+import cn.edu.tsinghua.tsfile.file.footer.ChunkGroupFooter;
 import cn.edu.tsinghua.tsfile.write.schema.MeasurementSchema;
 import cn.edu.tsinghua.tsfile.exception.write.WriteProcessException;
 import cn.edu.tsinghua.tsfile.write.writer.TsFileIOWriter;
@@ -35,7 +36,7 @@ public interface IChunkGroupWriter {
      * @param tsfileWriter - TSFileIOWriter
      * @throws IOException exception in IO
      */
-    void flushToFileWriter(TsFileIOWriter tsfileWriter) throws IOException;
+    ChunkGroupFooter flushToFileWriter(TsFileIOWriter tsfileWriter) throws IOException;
 
     /**
      * get the max memory occupied at this time.
@@ -56,14 +57,15 @@ public interface IChunkGroupWriter {
     void addSeriesWriter(MeasurementSchema measurementSchema, int pageSize);
 
     /**
-     * @return get the serialized size of current chunkGroup header + all chunks
+     * @return get the serialized size of current chunkGroup header + all chunks.
+     * Notice, the value does not include any un-sealed page in the chunks.
      */
     long getCurrentChunkGroupSize();
 
     /**
-     * call all the series to prepare to flush data.
+     * seal all the chunks which may has un-sealed pages in force.
      */
-    void preFlush();
+    void sealAllChunks();
 
     int getSeriesNumber();
 }

--- a/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/IChunkGroupWriter.java
+++ b/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/IChunkGroupWriter.java
@@ -62,10 +62,5 @@ public interface IChunkGroupWriter {
      */
     long getCurrentChunkGroupSize();
 
-    /**
-     * seal all the chunks which may has un-sealed pages in force.
-     */
-    void sealAllChunks();
-
     int getSeriesNumber();
 }

--- a/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/IChunkWriter.java
+++ b/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/chunk/IChunkWriter.java
@@ -59,15 +59,16 @@ public interface IChunkWriter {
     long estimateMaxSeriesMemSize();
 
     /**
-     * return the serialized size of the chunk header + all pages
+     * return the serialized size of the chunk header + all pages (not include the un-sealed page).
+     * Notice, call this method before calling writeToFileWriter(), otherwise the page buffer in memory will be cleared.
      */
     long getCurrentChunkSize();
 
     /**
-     * prepare to flush data into file.
+     * seal the current page which may has not enough data points in force.
      *
      */
-    void preFlush();
+    void sealCurrentPage();
 
     int getNumOfPages();
 }

--- a/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/writer/TsFileIOWriter.java
+++ b/tsfile/src/main/java/cn/edu/tsinghua/tsfile/write/writer/TsFileIOWriter.java
@@ -103,12 +103,9 @@ public class TsFileIOWriter {
      * @param dataSize the serialized size of all chunks
      * @return the serialized size of ChunkGroupFooter
      */
-    public ChunkGroupFooter startFlushChunkGroup(String deviceId, long dataSize, int numberOfChunks) throws IOException {
+    public void startFlushChunkGroup(String deviceId) throws IOException {
         LOG.debug("start chunk group:{}, file position {}", deviceId, out.getPosition());
         currentChunkGroupMetaData = new ChunkGroupMetaData(deviceId, new ArrayList<>());
-        ChunkGroupFooter footer = new ChunkGroupFooter(deviceId, dataSize, numberOfChunks);
-        LOG.debug("finishing writing chunk group header {}, file position {}", footer, out.getPosition());
-        return footer;
     }
 
     /**

--- a/tsfile/src/test/java/cn/edu/tsinghua/tsfile/write/TsFileIOWriterTest.java
+++ b/tsfile/src/test/java/cn/edu/tsinghua/tsfile/write/TsFileIOWriterTest.java
@@ -36,9 +36,10 @@ public class TsFileIOWriterTest {
         statistics.updateStats(0L);
 
         // chunk group 1
-        ChunkGroupFooter footer = writer.startFlushChunkGroup(deviceId, 0, 0);
+        writer.startFlushChunkGroup(deviceId);
         writer.startFlushChunk(measurementSchema, measurementSchema.getCompressor().getType(), measurementSchema.getType(), measurementSchema.getEncodingType(), statistics, 0, 0, 0, 0);
         writer.endChunk(0);
+        ChunkGroupFooter footer = new ChunkGroupFooter(deviceId, 0, 1);
         writer.endChunkGroup(footer);
 
         // end file


### PR DESCRIPTION
fix issue #524 .

Then, there are two works left:

is the data size in `ChunkGroupFooter` meaningful?

if `MemtableFlushUtils.flushMemTable()` needs to call low-level functions, I think the `TsFileIOWriter` needs to be redesigned.

I will try to fix the above two problem tomorrow.