### PR TITLE
Remove plugin duplicates in POM to avoid warnings

### DIFF
--- a/grafana/pom.xml
+++ b/grafana/pom.xml
@@ -85,19 +85,6 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-war-plugin</artifactId>
-					<configuration>
-						<failOnMissingWebXml>false</failOnMissingWebXml>
-						<archive>
-							<manifest>
-								<mainClass>${start-class}</mainClass>
-								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-							</manifest>
-						</archive>
-					</configuration>
-				</plugin>
-				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<configuration>

--- a/iotdb/pom.xml
+++ b/iotdb/pom.xml
@@ -9,7 +9,7 @@
 	    <relativePath>../pom.xml</relativePath>
     </parent>
 
-	<artifactId>IoTDB</artifactId>
+	<artifactId>iotdb</artifactId>
 
 	<name>IoTDB</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,15 @@
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<configuration>
 						<excludePackageNames>*thrift*</excludePackageNames>
+						<!--
+                          This will suppress the generation of a hidden timestamp at the top of each generated html page
+                          and hopefully let the site generation nod to too big updates every time.
+                        -->
+						<notimestamp>true</notimestamp>
+						<!--
+                          Don't fail the build, just because there were issues in the JavaDoc generation.
+                        -->
+						<failOnError>false</failOnError>
 					</configuration>
 				</plugin>
 				<!--
@@ -139,22 +148,6 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
 						<argLine>-Xmx512m</argLine>
-					</configuration>
-				</plugin>
-
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<configuration>
-						<!--
-                          This will suppress the generation of a hidden timestamp at the top of each generated html page
-                          and hopefully let the site generation nod to too big updates every time.
-                        -->
-						<notimestamp>true</notimestamp>
-						<!--
-                          Don't fail the build, just because there were issues in the JavaDoc generation.
-                        -->
-						<failOnError>false</failOnError>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
- Fix: removed plugin items which are duplicated in the same pom
- Fix: artifactId should be lowercase letters