### PR TITLE
Fix issue #536 OpenFileNumUtilTest UT test failure

### DIFF
--- a/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
+++ b/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
@@ -117,7 +117,6 @@ public class OpenFileNumUtil {
 
     /**
      * set pid
-     *
      * @param pid is the process ID of IoTDB service process
      */
     void setPid(int pid) {

--- a/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
+++ b/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
@@ -43,7 +43,13 @@ public class OpenFileNumUtil {
         METADATA_OPEN_FILE_NUM(Collections.singletonList(config.metadataDir)),
         DIGEST_OPEN_FILE_NUM(Collections.singletonList(config.fileNodeDir)),
         SOCKET_OPEN_FILE_NUM(null);
+
         private List<String> path;
+
+        public List<String> getPath() {
+            return path;
+        }
+
         OpenFileNumStatistics(List<String> path){
             this.path = path;
         }

--- a/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
+++ b/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
@@ -49,7 +49,6 @@ public class OpenFileNumUtil {
         public List<String> getPath() {
             return path;
         }
-
         OpenFileNumStatistics(List<String> path){
             this.path = path;
         }

--- a/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
+++ b/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
@@ -44,6 +44,8 @@ public class OpenFileNumUtil {
         DIGEST_OPEN_FILE_NUM(Collections.singletonList(config.fileNodeDir)),
         SOCKET_OPEN_FILE_NUM(null);
 
+        // path is a list of directory corresponding to the OpenFileNumStatistics enum element,
+        // e.g. data/data/ for DATA_OPEN_FILE_NUM
         private List<String> path;
 
         public List<String> getPath() {

--- a/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
+++ b/iotdb/src/main/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtil.java
@@ -49,6 +49,7 @@ public class OpenFileNumUtil {
         public List<String> getPath() {
             return path;
         }
+
         OpenFileNumStatistics(List<String> path){
             this.path = path;
         }

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -2,7 +2,6 @@ package cn.edu.tsinghua.iotdb.utils;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +28,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 88;
+    private int testFileNum = 66;
     private String currDir;
     private String os = System.getProperty("os.name").toLowerCase();
 
@@ -38,8 +37,12 @@ public class OpenFileNumUtilTest {
         int testProcessID = getProcessID();
         LOGGER.info("OpenFileNumUtilTest test process ID: {}", testProcessID);
         openFileNumUtil.setPid(testProcessID);
-        currDir = System.getProperty("user.dir");
-        testFileName = File.separator + TEST_FILE_PREFIX + testProcessID;
+        String dataFilePath = OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM.getPath().get(0);
+        String userDir = System.getProperty("user.dir");
+        LOGGER.info("Current user dir: {}", userDir);
+        currDir = userDir + File.separator + dataFilePath;
+        LOGGER.info("Test file dir: {}", currDir);
+        testFileName = TEST_FILE_PREFIX + testProcessID;
     }
 
     @After
@@ -69,30 +72,30 @@ public class OpenFileNumUtilTest {
     }
 
     @Test
-    public void testTotalOpenFileNumWhenCreateFile() {
+    public void testDataOpenFileNumWhenCreateFile() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             //get total open file number statistics of original state
-            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             for (int i = 0; i < testFileNum; i++) {
                 fileList.add(new File(currDir + testFileName + i));
             }
             //create testFileNum File，then get total open file number statistics
-            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             totalOpenFileNumChange = totalOpenFileNumAfter - totalOpenFileNumBefore;
             //create test file shall not affect total open file number statistics
             assertEquals(0, totalOpenFileNumChange);
         }else {
-            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM));
+            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM));
         }
     }
 
     @Test
-    public void testTotalOpenFileNumWhenCreateFileWriter() {
+    public void testDataOpenFileNumWhenCreateFileWriter() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
                 fileList.add(new File(currDir + testFileName + i));
             }
-            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             for (File file : fileList) {
                 if (file.exists()) {
                     try {
@@ -116,17 +119,17 @@ public class OpenFileNumUtilTest {
                     }
                 }
             }
-            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             totalOpenFileNumChange = totalOpenFileNumAfter - totalOpenFileNumBefore;
             //create FileWriter shall cause total open file number increase by testFileNum
             assertEquals(testFileNum, totalOpenFileNumChange);
         } else {
-            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM));
+            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM));
         }
     }
 
     @Test
-    public void testTotalOpenFileNumWhenFileWriterWriting() {
+    public void testDataOpenFileNumWhenFileWriterWriting() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
                 fileList.add(new File(currDir + testFileName + i));
@@ -153,7 +156,7 @@ public class OpenFileNumUtilTest {
                     }
                 }
             }
-            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             for (FileWriter fw : fileWriterList) {
                 try {
                     fw.write("this is a test file for open file number counting.");
@@ -161,17 +164,17 @@ public class OpenFileNumUtilTest {
                     LOGGER.error(e.getMessage());
                 }
             }
-            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             totalOpenFileNumChange = totalOpenFileNumAfter - totalOpenFileNumBefore;
             //writing test file shall not affect total open file number statistics
             assertEquals(0, totalOpenFileNumChange);
         } else {
-            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM));
+            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM));
         }
     }
 
     @Test
-    public void testTotalOpenFileNumWhenFileWriterClose() {
+    public void testDataOpenFileNumWhenFileWriterClose() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
                 fileList.add(new File(currDir + testFileName + i));
@@ -205,7 +208,7 @@ public class OpenFileNumUtilTest {
                     LOGGER.error(e.getMessage());
                 }
             }
-            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             for (FileWriter fw : fileWriterList) {
                 try {
                     fw.close();
@@ -213,12 +216,12 @@ public class OpenFileNumUtilTest {
                     LOGGER.error(e.getMessage());
                 }
             }
-            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
+            totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM);
             totalOpenFileNumChange = totalOpenFileNumAfter - totalOpenFileNumBefore;
             //close FileWriter shall cause total open file number decrease by testFileNum
             assertEquals(-testFileNum, totalOpenFileNumChange);
         } else {
-            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM));
+            assertEquals(-2, openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM));
         }
     }
 

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -31,7 +31,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumChange;
     private int testFileNum = 66;
     private String currDir;
-    private File testDataDir;
+    private File testDataDirRoot;
     private String os = System.getProperty("os.name").toLowerCase();
 
     @Before
@@ -42,12 +42,15 @@ public class OpenFileNumUtilTest {
         String dataFilePath = OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM.getPath().get(0);
         String userDir = System.getProperty("user.dir");
         LOGGER.info("Current user dir: {}", userDir);
-        currDir = userDir + File.separator + dataFilePath;
+        currDir = userDir + File.separator + testProcessID + File.separator + dataFilePath;
         LOGGER.info("Test file dir: {}", currDir);
-        testDataDir = new File(currDir);
-        if(!testDataDir.isDirectory()){
-            if(!testDataDir.mkdir()){
-                LOGGER.error("Create test file dir {} failed.", testDataDir.getPath());
+        File testDataDir = new File(currDir);
+        testDataDirRoot = new File(userDir + File.separator + testProcessID);
+        if(!testDataDir.exists()) {
+            if (!testDataDir.isDirectory()) {
+                if (!testDataDir.mkdirs()) {
+                    LOGGER.error("Create test file dir {} failed.", testDataDir.getPath());
+                }
             }
         }
         testFileName = TEST_FILE_PREFIX + testProcessID;
@@ -77,9 +80,9 @@ public class OpenFileNumUtilTest {
         fileWriterList.clear();
         fileList.clear();
         try {
-            FileUtils.deleteDirectory(testDataDir);
+            FileUtils.deleteDirectory(testDataDirRoot);
         } catch (IOException e) {
-            LOGGER.error("Delete test data dir {} failed.", testDataDir);
+            LOGGER.error("Delete test data dir {} failed.", testDataDirRoot);
         }
     }
 

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -74,10 +74,8 @@ public class OpenFileNumUtilTest {
                 }
             }
         }
-
         fileWriterList.clear();
         fileList.clear();
-
         try {
             FileUtils.deleteDirectory(testDataDir);
         } catch (IOException e) {

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -28,7 +28,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 88;
+    private int testFileNum = 80;
     private String currDir;
     private String os = System.getProperty("os.name").toLowerCase();
 

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -69,7 +69,6 @@ public class OpenFileNumUtilTest {
     }
 
     @Test
-    //@Ignore
     public void testTotalOpenFileNumWhenCreateFile() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             //get total open file number statistics of original state
@@ -88,7 +87,6 @@ public class OpenFileNumUtilTest {
     }
 
     @Test
-    //@Ignore
     public void testTotalOpenFileNumWhenCreateFileWriter() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
@@ -128,7 +126,6 @@ public class OpenFileNumUtilTest {
     }
 
     @Test
-    //@Ignore
     public void testTotalOpenFileNumWhenFileWriterWriting() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
@@ -174,7 +171,6 @@ public class OpenFileNumUtilTest {
     }
 
     @Test
-    //@Ignore
     public void testTotalOpenFileNumWhenFileWriterClose() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -4,51 +4,63 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.nio.file.Files;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 
 public class OpenFileNumUtilTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenFileNumUtilTest.class);
     private OpenFileNumUtil openFileNumUtil = OpenFileNumUtil.getInstance();
     private ArrayList<File> fileList = new ArrayList<>();
     private ArrayList<FileWriter> fileWriterList = new ArrayList<>();
-    private String testFileName = "/testFileForOpenFileNumUtil";
-    private String MAC_OS_NAME = "mac";
-    private String LINUX_OS_NAME = "linux";
+    private String testFileName;
+    private static final String TEST_FILE_PREFIX = "testFileForOpenFileNumUtil";
+    private static final String MAC_OS_NAME = "mac";
+    private static final String LINUX_OS_NAME = "linux";
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 66;
+    private int testFileNum = 6;
     private String currDir;
     private String os = System.getProperty("os.name").toLowerCase();
 
     @Before
-    public void setUp() throws Exception {
-        openFileNumUtil.setPid(getProcessID());
+    public void setUp() {
+        int testProcessID = getProcessID();
+        LOGGER.info("OpenFileNumUtilTest test process ID: {}", testProcessID);
+        openFileNumUtil.setPid(testProcessID);
         currDir = System.getProperty("user.dir");
+        testFileName = File.separator + TEST_FILE_PREFIX + testProcessID;
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         //close FileWriter
         for (FileWriter fw : fileWriterList) {
             try {
                 fw.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                LOGGER.error(e.getMessage());
             }
         }
 
         //delete test files
         for (File file : fileList) {
             if (file.exists()) {
-                file.delete();
+                try {
+                    Files.delete(file.toPath());
+                } catch (IOException e) {
+                    LOGGER.error(e.getMessage());
+                }
             }
         }
 
@@ -56,9 +68,8 @@ public class OpenFileNumUtilTest {
         fileList.clear();
     }
 
-    // TODO: Currently these tests have bugs. See https://github.com/thulab/iotdb/issues/536.
-//    @Test
-    @Ignore
+    @Test
+    //@Ignore
     public void testTotalOpenFileNumWhenCreateFile() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             //get total open file number statistics of original state
@@ -76,8 +87,8 @@ public class OpenFileNumUtilTest {
         }
     }
 
-//    @Test
-    @Ignore
+    @Test
+    //@Ignore
     public void testTotalOpenFileNumWhenCreateFileWriter() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
@@ -89,18 +100,21 @@ public class OpenFileNumUtilTest {
                     try {
                         fileWriterList.add(new FileWriter(file));
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                 } else {
                     try {
-                        file.createNewFile();
+                        boolean flag = file.createNewFile();
+                        if(!flag){
+                            LOGGER.error("create test file {} failed when execute testTotalOpenFileNumWhenCreateFileWriter().", file.getPath());
+                        }
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                     try {
                         fileWriterList.add(new FileWriter(file));
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                 }
             }
@@ -113,8 +127,8 @@ public class OpenFileNumUtilTest {
         }
     }
 
-//    @Test
-    @Ignore
+    @Test
+    //@Ignore
     public void testTotalOpenFileNumWhenFileWriterWriting() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
@@ -125,18 +139,20 @@ public class OpenFileNumUtilTest {
                     try {
                         fileWriterList.add(new FileWriter(file));
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                 } else {
                     try {
-                        file.createNewFile();
+                        if(!file.createNewFile()){
+                            LOGGER.error("create test file {} failed.", file.getPath());
+                        }
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                     try {
                         fileWriterList.add(new FileWriter(file));
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                 }
             }
@@ -145,7 +161,7 @@ public class OpenFileNumUtilTest {
                 try {
                     fw.write("this is a test file for open file number counting.");
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    LOGGER.error(e.getMessage());
                 }
             }
             totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
@@ -157,8 +173,8 @@ public class OpenFileNumUtilTest {
         }
     }
 
-//    @Test
-    @Ignore
+    @Test
+    //@Ignore
     public void testTotalOpenFileNumWhenFileWriterClose() {
         if(os.startsWith(MAC_OS_NAME) || os.startsWith(LINUX_OS_NAME)) {
             for (int i = 0; i < testFileNum; i++) {
@@ -169,18 +185,20 @@ public class OpenFileNumUtilTest {
                     try {
                         fileWriterList.add(new FileWriter(file));
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                 } else {
                     try {
-                        file.createNewFile();
+                        if(!file.createNewFile()){
+                            LOGGER.error("create test file {} failed when execute testTotalOpenFileNumWhenFileWriterClose().", file.getPath());
+                        }
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                     try {
                         fileWriterList.add(new FileWriter(file));
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error(e.getMessage());
                     }
                 }
             }
@@ -188,7 +206,7 @@ public class OpenFileNumUtilTest {
                 try {
                     fw.write("this is a test file for open file number counting.");
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    LOGGER.error(e.getMessage());
                 }
             }
             totalOpenFileNumBefore = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);
@@ -196,7 +214,7 @@ public class OpenFileNumUtilTest {
                 try {
                     fw.close();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    LOGGER.error(e.getMessage());
                 }
             }
             totalOpenFileNumAfter = openFileNumUtil.get(OpenFileNumUtil.OpenFileNumStatistics.TOTAL_OPEN_FILE_NUM);

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -40,7 +40,7 @@ public class OpenFileNumUtilTest {
         String dataFilePath = OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM.getPath().get(0);
         String userDir = System.getProperty("user.dir");
         LOGGER.info("Current user dir: {}", userDir);
-        currDir = userDir + File.separator + dataFilePath;
+        currDir = dataFilePath;
         LOGGER.info("Test file dir: {}", currDir);
         testFileName = TEST_FILE_PREFIX + testProcessID;
     }

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -29,7 +29,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 66;
+    private int testFileNum = 88;
     private String currDir;
     private String os = System.getProperty("os.name").toLowerCase();
 

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -29,7 +29,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 88;
+    private int testFileNum = 66;
     private String currDir;
     private File testDataDirRoot;
     private String os = System.getProperty("os.name").toLowerCase();

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -29,7 +29,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 66;
+    private int testFileNum = 88;
     private String currDir;
     private File testDataDirRoot;
     private String os = System.getProperty("os.name").toLowerCase();

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -28,7 +28,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 66;
+    private int testFileNum = 88;
     private String currDir;
     private String os = System.getProperty("os.name").toLowerCase();
 

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -29,7 +29,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 80;
+    private int testFileNum = 66;
     private String currDir;
     private File testDataDir;
     private String os = System.getProperty("os.name").toLowerCase();

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -13,6 +13,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import org.apache.commons.io.FileUtils;
 
 import static org.junit.Assert.assertEquals;
 
@@ -30,6 +31,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumChange;
     private int testFileNum = 80;
     private String currDir;
+    private File testDataDir;
     private String os = System.getProperty("os.name").toLowerCase();
 
     @Before
@@ -40,8 +42,14 @@ public class OpenFileNumUtilTest {
         String dataFilePath = OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM.getPath().get(0);
         String userDir = System.getProperty("user.dir");
         LOGGER.info("Current user dir: {}", userDir);
-        currDir = dataFilePath;
+        currDir = userDir + File.separator + dataFilePath;
         LOGGER.info("Test file dir: {}", currDir);
+        testDataDir = new File(currDir);
+        if(!testDataDir.isDirectory()){
+            if(!testDataDir.mkdir()){
+                LOGGER.error("Create test file dir {} failed.", testDataDir.getPath());
+            }
+        }
         testFileName = TEST_FILE_PREFIX + testProcessID;
     }
 
@@ -69,6 +77,12 @@ public class OpenFileNumUtilTest {
 
         fileWriterList.clear();
         fileList.clear();
+
+        try {
+            FileUtils.deleteDirectory(testDataDir);
+        } catch (IOException e) {
+            LOGGER.error("Delete test data dir {} failed.", testDataDir);
+        }
     }
 
     @Test

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -29,7 +29,7 @@ public class OpenFileNumUtilTest {
     private int totalOpenFileNumBefore;
     private int totalOpenFileNumAfter;
     private int totalOpenFileNumChange;
-    private int testFileNum = 6;
+    private int testFileNum = 66;
     private String currDir;
     private String os = System.getProperty("os.name").toLowerCase();
 

--- a/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
+++ b/iotdb/src/test/java/cn/edu/tsinghua/iotdb/utils/OpenFileNumUtilTest.java
@@ -37,13 +37,10 @@ public class OpenFileNumUtilTest {
     @Before
     public void setUp() {
         int testProcessID = getProcessID();
-        LOGGER.info("OpenFileNumUtilTest test process ID: {}", testProcessID);
         openFileNumUtil.setPid(testProcessID);
         String dataFilePath = OpenFileNumUtil.OpenFileNumStatistics.DATA_OPEN_FILE_NUM.getPath().get(0);
         String userDir = System.getProperty("user.dir");
-        LOGGER.info("Current user dir: {}", userDir);
         currDir = userDir + File.separator + testProcessID + File.separator + dataFilePath;
-        LOGGER.info("Test file dir: {}", currDir);
         File testDataDir = new File(currDir);
         testDataDirRoot = new File(userDir + File.separator + testProcessID);
         if(!testDataDir.exists()) {


### PR DESCRIPTION
Fix issue #536 
All test files now are generated in a pid-specific dir and the test is aim at open file number statistics under data path.