### PR TITLE
replace  antlr3 maven plugin with antlr-runtime 

### DIFF
--- a/iotdb-cli/pom.xml
+++ b/iotdb-cli/pom.xml
@@ -47,7 +47,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.1.0</version>
 				<configuration>
 					<filesets>
 						<fileset>
@@ -63,7 +62,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.10</version>
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>
@@ -77,30 +75,13 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.7</version>
-				<executions>
-					<execution>
-						<id>copy-native-libraries</id>
-						<phase>package</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								
-								<copy todir="${project.basedir}/cli/lib">
-									<fileset dir="${project.basedir}/target/">
-										<include name="*.jar" />
-									</fileset>
-								</copy>
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+		    <plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-jar-plugin</artifactId>
+		        <configuration>
+		            <outputDirectory>${project.basedir}/cli/lib</outputDirectory>
+		        </configuration>
+		    </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/iotdb/pom.xml
+++ b/iotdb/pom.xml
@@ -15,6 +15,7 @@
 
 	<properties>
 		<antlr3.version>3.5.2</antlr3.version>
+		<common.lang3.version>3.8.1</common.lang3.version>
 		<iotdb.test.skip>false</iotdb.test.skip>
 		<it.test.includes>**/*Test.java</it.test.includes>
 		<it.test.excludes>**/NoTest.java</it.test.excludes>
@@ -70,10 +71,17 @@
 			<artifactId>commons-collections4</artifactId>
 			<version>${commons.collections4}</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.antlr/antlr-runtime -->
 		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr3-maven-plugin</artifactId>
-			<version>${antlr3.version}</version>
+		    <groupId>org.antlr</groupId>
+		    <artifactId>antlr-runtime</artifactId>
+		    <version>${antlr3.version}</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-lang3</artifactId>
+		    <version>${common.lang3.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -93,6 +101,7 @@
 					</filesets>
 				</configuration>
 			</plugin>
+
 
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/iotdb/pom.xml
+++ b/iotdb/pom.xml
@@ -81,7 +81,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.1.0</version>
 				<configuration>
 					<filesets>
 						<fileset>
@@ -111,7 +110,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.10</version>
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>
@@ -125,7 +123,13 @@
 					</execution>
 				</executions>
 			</plugin>
-
+		    <plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-jar-plugin</artifactId>
+		        <configuration>
+		            <outputDirectory>${project.basedir}/iotdb/lib</outputDirectory>
+		        </configuration>
+		    </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -140,31 +144,6 @@
 					</includes>
 				</configuration>
 			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.7</version>
-				<executions>
-					<execution>
-						<id>copy-native-libraries</id>
-						<phase>package</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								<copy todir="${project.basedir}/iotdb/lib">
-									<fileset dir="${project.basedir}/target/">
-										<include name="*.jar" />
-									</fileset>
-								</copy>
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 			<!-- Might require this in Eclipse -->
 			<!--plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/iotdb/src/main/java/cn/edu/tsinghua/iotdb/sql/parse/ASTNode.java
+++ b/iotdb/src/main/java/cn/edu/tsinghua/iotdb/sql/parse/ASTNode.java
@@ -10,9 +10,7 @@ import java.util.List;
 import org.antlr.runtime.Token;
 import org.antlr.runtime.tree.CommonTree;
 import org.antlr.runtime.tree.Tree;
-
-import org.codehaus.plexus.util.StringUtils;
-
+import org.apache.commons.lang3.StringUtils;;
 
 public class ASTNode extends CommonTree implements Node, Serializable {
 	private static final long serialVersionUID = 1L;

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>${logback.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>


### PR DESCRIPTION
You have a dependency on the antlr3 maven plugin. Instead you should depend on the antlr-runtime artifact that matches your antlr3 version.
By Chris

solve #500 
checklist 12